### PR TITLE
Fix server path for Windows

### DIFF
--- a/src/kv/extension.ts
+++ b/src/kv/extension.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from "vscode";
 import { KvViewProvider } from "./webview";
+import * as path from 'path';
 import { ChildProcess, spawn } from "child_process";
 
 let process: ChildProcess | null = null;
@@ -20,16 +21,16 @@ export function activate(context: vscode.ExtensionContext) {
     return;
   }
 
-  const serverSrc = vscode.Uri.joinPath(
-    context.extensionUri,
+  const serverSrcPath = path.join(
+    context.extensionUri.fsPath,
     "scripts",
     "kv",
-    "server.ts",
+    "server.ts"
   );
 
   process = spawn(
     "deno",
-    ["run", "-A", "--unstable", serverSrc.path],
+    ["run", "-A", "--unstable", serverSrcPath],
     {
       cwd: workspaceRoute,
     },


### PR DESCRIPTION
On Windows the extension ends up stuck while loading, this is a fix for the first error:

![image](https://github.com/hashrock/kivi/assets/3296866/33d3af06-478a-458d-a37c-57104c469bcd)

I think there are more issues though.